### PR TITLE
fix: index out of range

### DIFF
--- a/release/RELEASE
+++ b/release/RELEASE
@@ -1,4 +1,4 @@
-tag: v1.7.0
+tag: v1.7.1
 prerelease: false
 
 releaseNoteGenerator:

--- a/tenv.go
+++ b/tenv.go
@@ -171,6 +171,9 @@ func targetRunner(params []*ast.Field, fileName string) (string, bool) {
 			}
 		case *ast.SelectorExpr:
 			if checkSelectorExprTarget(typ) {
+				if len(p.Names) == 0 {
+					return "", false
+				}
 				argName := p.Names[0].Name
 				return argName, true
 			}

--- a/testdata/src/a/a_test.go
+++ b/testdata/src/a/a_test.go
@@ -71,3 +71,7 @@ func TestFunctionLiteral(t *testing.T) {
 func TestEmpty(t *testing.T) {
 	t.Run("test", func(*testing.T) {})
 }
+
+func TestEmptyTB(t *testing.T) {
+	func(testing.TB) {}(t)
+}


### PR DESCRIPTION
Found this panic while running tenv in golangci-lint. See https://github.com/coder/coder/pull/4687 for code that can reproduce.

```
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
ERRO [runner] Panic: tenv: package "tailnet_test" (isInitialPkg: true, needAnalyzeSource: true): runtime error: index out of range [0] with length 0: goroutine 79536 [running]:
runtime/debug.Stack()
	/usr/lib/go/src/runtime/debug/stack.go:24 +0x65
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe.func1()
	/home/colin/go/pkg/mod/github.com/golangci/golangci-lint@v1.50.1/pkg/golinters/goanalysis/runner_action.go:102 +0x155
panic({0x165cc80, 0xc02d4ca708})
	/usr/lib/go/src/runtime/panic.go:884 +0x212
github.com/sivchari/tenv.targetRunner({0xc0289ac7d8, 0x1, 0x2?}, {0xc00123c730, 0x47})
	/home/colin/go/pkg/mod/github.com/sivchari/tenv@v1.7.0/tenv.go:174 +0x405
github.com/sivchari/tenv.checkFuncLit(0xc00094e340?, 0xc0093ac140, {0xc00123c730?, 0x0?})
	/home/colin/go/pkg/mod/github.com/sivchari/tenv@v1.7.0/tenv.go:62 +0x4e
github.com/sivchari/tenv.run.func1({0x194d078?, 0xc0093ac140?})
	/home/colin/go/pkg/mod/github.com/sivchari/tenv@v1.7.0/tenv.go:46 +0xa5
golang.org/x/tools/go/ast/inspector.(*Inspector).Preorder(0xc02a270408, {0xc0034b8d18?, 0x2?, 0x914a27?}, 0xc02c69fd08)
	/home/colin/go/pkg/mod/golang.org/x/tools@v0.2.0/go/ast/inspector/inspector.go:77 +0x9a
github.com/sivchari/tenv.run(0xc02d4ed520)
	/home/colin/go/pkg/mod/github.com/sivchari/tenv@v1.7.0/tenv.go:41 +0xa5
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyze(0xc005efc410)
	/home/colin/go/pkg/mod/github.com/golangci/golangci-lint@v1.50.1/pkg/golinters/goanalysis/runner_action.go:188 +0x9d6
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe.func2()
	/home/colin/go/pkg/mod/github.com/golangci/golangci-lint@v1.50.1/pkg/golinters/goanalysis/runner_action.go:106 +0x1d
github.com/golangci/golangci-lint/pkg/timeutils.(*Stopwatch).TrackStage(0xc0011d66e0, {0x16c12ce, 0x4}, 0xc0034b8f48)
	/home/colin/go/pkg/mod/github.com/golangci/golangci-lint@v1.50.1/pkg/timeutils/stopwatch.go:111 +0x4a
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*action).analyzeSafe(0xc02ec88800?)
	/home/colin/go/pkg/mod/github.com/golangci/golangci-lint@v1.50.1/pkg/golinters/goanalysis/runner_action.go:105 +0x85
github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze.func2(0xc005efc410)
	/home/colin/go/pkg/mod/github.com/golangci/golangci-lint@v1.50.1/pkg/golinters/goanalysis/runner_loadingpackage.go:80 +0xb4
created by github.com/golangci/golangci-lint/pkg/golinters/goanalysis.(*loadingPackage).analyze
	/home/colin/go/pkg/mod/github.com/golangci/golangci-lint@v1.50.1/pkg/golinters/goanalysis/runner_loadingpackage.go:75 +0x1eb
WARN [runner] Can't run linter goanalysis_metalinter: goanalysis_metalinter: tenv: package "tailnet_test" (isInitialPkg: true, needAnalyzeSource: true): runtime error: index out of range [0] with length 0
ERRO Running error: 1 error occurred:
	* can't run linter goanalysis_metalinter: goanalysis_metalinter: tenv: package "tailnet_test" (isInitialPkg: true, needAnalyzeSource: true): runtime error: index out of range [0] with length 0
```