### PR TITLE
feat: allow to specify Go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ go vet -vettool=$(which tenv) -tenv.all ./...
 ./main_test.go:19:2: os.Setenv() can be replaced by `testing.Setenv()` in helper
 ```
 
-The option `go` allows to specify Go version. If the version is not empty and lower than Go 1.17 the analysis will be skipped.
+The option `go` allows to specify Go version. If the version is not empty or lower than Go 1.17, the analysis will be skipped.
 
 ```console
 go vet -vettool=$(which tenv) -tenv.go 1.16 ./...

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ go vet -vettool=(which tenv) ./...
 
 ### option
 
-The option `all` will run against whole test files (`_test.go`) regardless of method/function signatures.  
+The option `all` will run against whole test files (`_test.go`) regardless of method/function signatures.
+
+The option `go` allows to specify Go version. If the version is not empty and lower than Go 1.17 the analysis will be skipped.
 
 By default, only methods that take `*testing.T`, `*testing.B`, and `testing.TB` as arguments are checked.
 

--- a/README.md
+++ b/README.md
@@ -45,11 +45,9 @@ go vet -vettool=(which tenv) ./...
 ./main_test.go:11:2: os.Setenv() can be replaced by `t.Setenv()` in TestMain
 ```
 
-### option
+### options
 
 The option `all` will run against whole test files (`_test.go`) regardless of method/function signatures.
-
-The option `go` allows to specify Go version. If the version is not empty and lower than Go 1.17 the analysis will be skipped.
 
 By default, only methods that take `*testing.T`, `*testing.B`, and `testing.TB` as arguments are checked.
 
@@ -77,12 +75,19 @@ func helper() {
 ```
 
 ```console
-go vet -vettool=(which tenv) -tenv.all ./...
+go vet -vettool=$(which tenv) -tenv.all ./...
 
 # a
 ./main_test.go:11:2: os.Setenv() can be replaced by `t.Setenv()` in TestMain
 ./main_test.go:19:2: os.Setenv() can be replaced by `testing.Setenv()` in helper
 ```
+
+The option `go` allows to specify Go version. If the version is not empty and lower than Go 1.17 the analysis will be skipped.
+
+```console
+go vet -vettool=$(which tenv) -tenv.go 1.16 ./...
+
+Outputs nothing because specified Go 1.16 is lower than 1.17.
 
 ## CI
 

--- a/tenv_test.go
+++ b/tenv_test.go
@@ -14,3 +14,10 @@ func TestAnalyzer(t *testing.T) {
 	testdata := testutil.WithModules(t, analysistest.TestData(), nil)
 	analysistest.Run(t, testdata, tenv.Analyzer, "a")
 }
+
+func TestAnalyzerGo116(t *testing.T) {
+	testdata := testutil.WithModules(t, analysistest.TestData(), nil)
+	a := tenv.Analyzer
+	a.Flags.Parse([]string{"-go", "1.16"})
+	analysistest.Run(t, testdata, a, "go116")
+}

--- a/tenv_test.go
+++ b/tenv_test.go
@@ -21,3 +21,30 @@ func TestAnalyzerGo116(t *testing.T) {
 	a.Flags.Parse([]string{"-go", "1.16"})
 	analysistest.Run(t, testdata, a, "go116")
 }
+
+func TestRun(t *testing.T) {
+	t.Run("empty Go version", func(t *testing.T) {
+		for _, goVersion := range []string{
+			"", "go",
+		} {
+			testdata := testutil.WithModules(t, analysistest.TestData(), nil)
+			a := tenv.Analyzer
+			a.Flags.Parse([]string{"-go", goVersion})
+			analysistest.Run(t, testdata, a, "a")
+		}
+	})
+
+	t.Run("invalid Go version", func(t *testing.T) {
+		for _, goVersion := range []string{
+			"go1", "goa.2", "go1.a",
+		} {
+			a := tenv.Analyzer
+			a.Flags.Parse([]string{"-go", goVersion})
+			_, err := a.Run(nil)
+
+			if err == nil {
+				t.Error("expected error, but got <nil>")
+			}
+		}
+	})
+}

--- a/testdata/src/go116/go.mod
+++ b/testdata/src/go116/go.mod
@@ -1,0 +1,3 @@
+module go116
+
+go 1.16

--- a/testdata/src/go116/go116_test.go
+++ b/testdata/src/go116/go116_test.go
@@ -1,0 +1,12 @@
+package go116
+
+import (
+	"os"
+	"testing"
+)
+
+func TestF(t *testing.T) {
+	os.Setenv("a", "b")        // if -go = 1.16, ""
+	err := os.Setenv("a", "b") // if -go = 1.16, ""
+	_ = err
+}


### PR DESCRIPTION
This PR adds `-go` flag to specify Go version. This is needed for `golangci-lint` to skip running `tenv` if the Go version is lower than `1.17`. Because `T.Setenv` was added in `go1.17`.