### PR TITLE
fix: downgrade min Go version to go1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sivchari/tenv
 
-go 1.22.3
+go 1.21.0
 
 require (
 	github.com/gostaticanalysis/testutil v0.4.0


### PR DESCRIPTION
Since go1.21, the Go version inside the `go.mod` is a hard requirement.

Golangci-lint needs to run with go1.21.

https://github.com/golangci/golangci-lint/pull/4803
