### PR TITLE
Decrease Gopher image width in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tenv
 
-![tenv Gopher](./tenv.png "Gopher")
+<img title="Gopher" alt="tenv Gopher" src="./tenv.png" width="400">
 
 
 [![test_and_lint](https://github.com/sivchari/tenv/actions/workflows/workflows.yml/badge.svg?branch=main)](https://github.com/sivchari/tenv/actions/workflows/workflows.yml)


### PR DESCRIPTION
I propose to decrease the logo because it's too large.

Before:
<img width="410" alt="image" src="https://github.com/sivchari/tenv/assets/3228886/0abd3471-dc9c-4868-b211-46a9dca5a35b">


After:
<img width="410" alt="image" src="https://github.com/sivchari/tenv/assets/3228886/7d1b7f7f-03af-4579-9c04-9b3d41c4bf3b">
