### PR TITLE
Fix panic when accessing the package name of a prelude object

### DIFF
--- a/tenv.go
+++ b/tenv.go
@@ -169,7 +169,13 @@ func checkAssignStmt(pass *analysis.Pass, stmt *ast.AssignStmt, funcName, argNam
 }
 
 func checkObj(pass *analysis.Pass, obj types.Object, pos token.Pos, funcName, argName string) bool {
-	targetName := fmt.Sprintf("%s.%s", obj.Pkg().Name(), obj.Name())
+	// For built-in objects, obj.Pkg() returns nil.
+	var pkgPrefix string
+	if pkg := obj.Pkg(); pkg != nil {
+		pkgPrefix = pkg.Name() + "."
+	}
+
+	targetName := pkgPrefix + obj.Name()
 	if targetName == "os.Setenv" {
 		if argName == "" {
 			argName = "testing"

--- a/tenv_test.go
+++ b/tenv_test.go
@@ -14,3 +14,8 @@ func TestAnalyzer(t *testing.T) {
 	testdata := testutil.WithModules(t, analysistest.TestData(), nil)
 	analysistest.Run(t, testdata, tenv.Analyzer, "a")
 }
+
+func TestRegression(t *testing.T) {
+	testdata := testutil.WithModules(t, analysistest.TestData(), nil)
+	analysistest.Run(t, testdata, tenv.Analyzer, "regression")
+}

--- a/testdata/src/regression/builtin_functions_have_no_package.go
+++ b/testdata/src/regression/builtin_functions_have_no_package.go
@@ -1,0 +1,10 @@
+package regression_test
+
+import "testing"
+
+func TestBuiltInFunctionsHaveNoPkg(t *testing.T) {
+	// Built-in definitions have no package, which means that "go/types".Object.Pkg() returns nil,
+	// which in turn panics when its method Name() is called.
+	var items []int
+	items = append(items, 0)
+}

--- a/testdata/src/regression/go.mod
+++ b/testdata/src/regression/go.mod
@@ -1,0 +1,3 @@
+module regression
+
+go 1.22.3


### PR DESCRIPTION
Patches a bug introduced in v1.12.0.