### PR TITLE
fix: go minimum version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/sivchari/tenv
 
-go 1.22.3
+go 1.22.0
+
+toolchain go1.22.3
 
 require (
 	github.com/gostaticanalysis/testutil v0.4.0


### PR DESCRIPTION
The minimum version defined by `go` is a hard requirement for applications that depend on `tenv` as a lib.

The minimum version defined by `toolchain` only applies to the build of the `tenv` binary.