### PR TITLE
docs: fix CI badge link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img title="Gopher" alt="tenv Gopher" src="./tenv.png" width="400">
 
 
-[![test_and_lint](https://github.com/sivchari/tenv/actions/workflows/workflows.yml/badge.svg?branch=main)](https://github.com/sivchari/tenv/actions/workflows/workflows.yml)
+[![test](https://github.com/sivchari/tenv/actions/workflows/test.yaml/badge.svg?branch=main)](https://github.com/sivchari/tenv/actions/workflows/test.yaml)
 
 tenv is analyzer that detects using os.Setenv instead of t.Setenv since Go1.17
 


### PR DESCRIPTION
After #43, the link to the badge in the README became invalid. This PR fixes that.